### PR TITLE
Add execution route to remove self owned name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ This command will produce a file called `name_smart_contract.wasm` that can then
 by using the `provenanced` command.  
 
 The command stems from: https://github.com/provenance-io/provenance
-A great tutorial for getting a wasm built and deployed: https://github.com/provenance-io/provwasm/tree/main/docs/tutorial
 
+A great tutorial for getting a wasm built and deployed: https://github.com/provenance-io/provwasm/tree/main/docs/tutorial

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,10 +8,10 @@ pub enum ContractError {
 
     #[error("Unauthorized")]
     Unauthorized,
+
     // Add any other custom errors you like here.
     // Look at https://docs.rs/thiserror/1.0.21/thiserror/ for details.
     #[error("Name [{name:?}] is already registered")]
-    // The msg param is strictly for internal testing
     NameRegistered { name: String },
 
     #[error("Name serialization failed due to {cause:?}")]
@@ -19,6 +19,9 @@ pub enum ContractError {
 
     #[error("Name not found")]
     NameNotFound,
+
+    #[error("Name not owned")]
+    NameNotOwned,
 
     #[error("No nhash amount provided during name registration")]
     NoFundsProvidedForRegistration,

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -16,6 +16,7 @@ pub struct InitMsg {
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
     Register { name: String },
+    RemoveOwnedName { name: String },
 }
 
 /// A message sent to query contract config state.


### PR DESCRIPTION
This adds a new execution route, `remove_owed_name`, that can delete a singular name that is owned by the sender.   This also exposes an issue in the provenance message system (potentially unless I'm missing something), because you need to delete all attributes at once.  Our system registers attributes under a single name, so they must be deleted simultaneously and then all names that were not deleted need to be re-added as their own provenance messages.  This is obviously inefficient and massively bloats gas fees.

Ideally, the backend blockchain attribute handler should have a route that will let you delete an attribute that has a specified value.  This would make this much easier.  Either that, or the blockchain should allow attributes to be queried in a fuzzy manner, so we could register attributes as their fully-qualified names instead.

Our current setup is: 
1. Choose root name (ex: wallet.pb)
2. Add new name as an attribute (key: wallet.pb, value: name)

We could just register them as:
key: name.wallet.pb

But then we'd need a way to find all "x.wallet.pb" attributes, which we don't currently have, as far as I can tell.