### PR TITLE
Upgrade to CosmWasm 1.0.0 Beta 5 / ProvWasm 1.0.0 Beta 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,8 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 
 [dependencies]
 provwasm-std = { version = "1.0.0-beta" }
-cosmwasm-std = { version = "1.0.0-beta", features = ["iterator"] }
-cosmwasm-storage = { version = "1.0.0-beta", features = ["iterator"] }
+cosmwasm-std = { version = "1.0.0-beta" }
+cosmwasm-storage = { version = "1.0.0-beta" }
 cw-storage-plus = "0.8.0"
 cw2 = "0.8.1"
 schemars = "0.8.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,9 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-provwasm-std = { version = "0.16.0"}
-cosmwasm-std = { version = "0.16.2" }
-cosmwasm-storage = { version = "0.16.2" }
+provwasm-std = { version = "1.0.0-beta" }
+cosmwasm-std = { version = "1.0.0-beta5" }
+cosmwasm-storage = { version = "1.0.0-beta5" }
 cw-storage-plus = "0.8.0"
 cw2 = "0.8.1"
 schemars = "0.8.3"
@@ -51,5 +51,5 @@ serde-json-wasm = { version = "0.3.1" }
 thiserror = { version = "1.0.26" }
 
 [dev-dependencies]
-provwasm-mocks = { version = "0.16.0" }
-cosmwasm-schema = { version = "0.16.2" }
+provwasm-mocks = { version = "1.0.0-beta" }
+cosmwasm-schema = { version = "1.0.0-beta5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,8 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 
 [dependencies]
 provwasm-std = { version = "1.0.0-beta" }
-cosmwasm-std = { version = "1.0.0-beta5" }
-cosmwasm-storage = { version = "1.0.0-beta5" }
+cosmwasm-std = { version = "1.0.0-beta", features = ["iterator"] }
+cosmwasm-storage = { version = "1.0.0-beta", features = ["iterator"] }
 cw-storage-plus = "0.8.0"
 cw2 = "0.8.1"
 schemars = "0.8.3"
@@ -52,4 +52,4 @@ thiserror = { version = "1.0.26" }
 
 [dev-dependencies]
 provwasm-mocks = { version = "1.0.0-beta" }
-cosmwasm-schema = { version = "1.0.0-beta5" }
+cosmwasm-schema = { version = "1.0.0-beta" }

--- a/schema/migrate_msg.json
+++ b/schema/migrate_msg.json
@@ -2,5 +2,19 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "MigrateMsg",
   "description": "Migrate the contract",
-  "type": "object"
+  "type": "object",
+  "properties": {
+    "new_fee_amount": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "new_fee_collection_address": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  }
 }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -9,13 +9,14 @@ use cosmwasm_std::{
 use cosmwasm_storage::Bucket;
 use provwasm_std::{
     add_attribute, bind_name, Attribute, Attributes, NameBinding, ProvenanceMsg, ProvenanceQuerier,
+    ProvenanceQuery,
 };
 
 ///
 /// INSTANTIATION SECTION
 ///
 pub fn instantiate(
-    deps: DepsMut,
+    deps: DepsMut<ProvenanceQuery>,
     env: Env,
     info: MessageInfo,
     msg: InitMsg,
@@ -54,7 +55,7 @@ pub fn instantiate(
 ///
 /// QUERY SECTION
 ///
-pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+pub fn query(deps: Deps<ProvenanceQuery>, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::QueryRequest {} => {
             let state = config_read(deps.storage).load()?;
@@ -72,7 +73,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     }
 }
 
-fn try_query_by_address(deps: Deps, address: String) -> StdResult<Binary> {
+fn try_query_by_address(deps: Deps<ProvenanceQuery>, address: String) -> StdResult<Binary> {
     // Implicitly pull the root registrar name out of the state
     let registrar_name = match config_read(deps.storage).load() {
         Ok(config) => config.name,
@@ -131,7 +132,7 @@ fn deserialize_name_from_attribute(attribute: &Attribute) -> String {
 
 /// Scans the entire storage for the target name string by doing direct matches.
 /// Will only ever return a maximum of MAX_NAME_SEARCH_RESULTS.
-fn search_for_names(deps: Deps, search: String) -> StdResult<Binary> {
+fn search_for_names(deps: Deps<ProvenanceQuery>, search: String) -> StdResult<Binary> {
     let meta_storage = meta_read(deps.storage);
     let search_str = search.as_str();
     let names = meta_storage
@@ -152,7 +153,7 @@ fn search_for_names(deps: Deps, search: String) -> StdResult<Binary> {
 /// EXECUTE SECTION
 ///
 pub fn execute(
-    deps: DepsMut,
+    deps: DepsMut<ProvenanceQuery>,
     _env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
@@ -164,7 +165,7 @@ pub fn execute(
 
 // register a name
 fn try_register(
-    deps: DepsMut,
+    deps: DepsMut<ProvenanceQuery>,
     info: MessageInfo,
     name: String,
 ) -> Result<Response<ProvenanceMsg>, ContractError> {
@@ -360,7 +361,11 @@ fn validate_fee_params_get_messages(
 ///
 /// TODO: Allow fee amount swap across migrations
 ///
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+pub fn migrate(
+    _deps: DepsMut<ProvenanceQuery>,
+    _env: Env,
+    _msg: MigrateMsg,
+) -> Result<Response, ContractError> {
     Ok(Response::default())
 }
 
@@ -939,7 +944,7 @@ mod tests {
 
     /// Helper to do a registration without all the extra boilerplate
     fn do_registration(
-        deps: DepsMut,
+        deps: DepsMut<ProvenanceQuery>,
         message_info: MessageInfo,
         name: String,
     ) -> Result<Response<ProvenanceMsg>, ContractError> {
@@ -954,10 +959,10 @@ mod tests {
     /// Driver for multiple instantiate types, on the chance that different defaults are needed
     enum InstArgs<'a> {
         Basic {
-            deps: DepsMut<'a>,
+            deps: DepsMut<'a, ProvenanceQuery>,
         },
         FeeParams {
-            deps: DepsMut<'a>,
+            deps: DepsMut<'a, ProvenanceQuery>,
             fee_amount: u128,
             fee_collection_address: &'a str,
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,3 @@ pub mod contract_info;
 pub mod error;
 pub mod msg;
 pub mod state;
-
-#[cfg(target_arch = "wasm32")]
-cosmwasm_std::create_entry_points_with_migration!(contract);

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,3 +1,5 @@
+use cosmwasm_std::{CosmosMsg, CustomMsg, Response};
+use provwasm_std::{ProvenanceMsg, ProvenanceMsgParams, ProvenanceRoute};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -34,7 +36,15 @@ pub type QueryResponse = State;
 /// Migrate the contract
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}
+pub struct MigrateMsg {
+    pub new_fee_amount: Option<String>,
+    pub new_fee_collection_address: Option<String>,
+}
+impl MigrateMsg {
+    pub fn has_fee_changes(&self) -> bool {
+        self.new_fee_amount.is_some() || self.new_fee_collection_address.is_some()
+    }
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -59,3 +69,30 @@ impl NameSearchResponse {
         NameSearchResponse { search, names }
     }
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct ProvenanceMsgV2 {
+    pub route: ProvenanceRoute,
+    pub params: ProvenanceMsgParams,
+    pub version: String,
+}
+impl ProvenanceMsgV2 {
+    pub fn from_cosmos(msg: CosmosMsg<ProvenanceMsg>) -> CosmosMsg<ProvenanceMsgV2> {
+        match msg {
+            CosmosMsg::Custom(provenance_msg) => {
+                CosmosMsg::Custom(ProvenanceMsgV2 {
+                    route: provenance_msg.route,
+                    params: provenance_msg.params,
+                    version: provenance_msg.version,
+                })
+            },
+            _ => panic!("unexpected message type provided to converter"),
+        }
+    }
+
+    pub fn from_prov(msg: ProvenanceMsg) -> ProvenanceMsgV2 {
+        ProvenanceMsgV2 { route: msg.route, params: msg.params, version: msg.version, }
+    }
+}
+impl CustomMsg for ProvenanceMsgV2 {}

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,5 +1,3 @@
-use cosmwasm_std::{CosmosMsg, CustomMsg, Response};
-use provwasm_std::{ProvenanceMsg, ProvenanceMsgParams, ProvenanceRoute};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -69,30 +67,3 @@ impl NameSearchResponse {
         NameSearchResponse { search, names }
     }
 }
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub struct ProvenanceMsgV2 {
-    pub route: ProvenanceRoute,
-    pub params: ProvenanceMsgParams,
-    pub version: String,
-}
-impl ProvenanceMsgV2 {
-    pub fn from_cosmos(msg: CosmosMsg<ProvenanceMsg>) -> CosmosMsg<ProvenanceMsgV2> {
-        match msg {
-            CosmosMsg::Custom(provenance_msg) => {
-                CosmosMsg::Custom(ProvenanceMsgV2 {
-                    route: provenance_msg.route,
-                    params: provenance_msg.params,
-                    version: provenance_msg.version,
-                })
-            },
-            _ => panic!("unexpected message type provided to converter"),
-        }
-    }
-
-    pub fn from_prov(msg: ProvenanceMsg) -> ProvenanceMsgV2 {
-        ProvenanceMsgV2 { route: msg.route, params: msg.params, version: msg.version, }
-    }
-}
-impl CustomMsg for ProvenanceMsgV2 {}


### PR DESCRIPTION
Provenance 1.8 is now released on testnet, and is not backwards compatible with provwasm 0.16.x / cosmwasm 0.16.x.  These changes are required in order for a new version to be migrated.  Additionally, I fleshed out the migration code a little bit to give us options in the future when we want to migrate this contract