### PR TITLE
Add Migration Versioning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "name-smart-contract"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Pierce Trey <ptrey@figure.com>", "Jake Schwartz <jschwartz@figure.com>"]
 edition = "2018"
 
@@ -43,9 +43,10 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 provwasm-std = { version = "1.0.0-beta" }
 cosmwasm-std = { version = "1.0.0-beta" }
 cosmwasm-storage = { version = "1.0.0-beta" }
-cw-storage-plus = "0.8.0"
-cw2 = "0.8.1"
+cw-storage-plus = "0.12.1"
+cw2 = "0.12.1"
 schemars = "0.8.3"
+semver = "1"
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 serde-json-wasm = { version = "0.3.1" }
 thiserror = { version = "1.0.26" }

--- a/schema/query_msg.json
+++ b/schema/query_msg.json
@@ -74,6 +74,18 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "version"
+      ],
+      "properties": {
+        "version": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,10 +24,16 @@ pub enum ContractError {
     NoFundsProvidedForRegistration,
 
     #[error("Previous contract name [{previous_contract:?}] does not match provided name [{provided_contract:?}]")]
-    InvalidContractName { previous_contract: String, provided_contract: String },
+    InvalidContractName {
+        previous_contract: String,
+        provided_contract: String,
+    },
 
     #[error("Previous contract version [{previous_version}] is higher than provided version [{provided_version}]")]
-    InvalidContractVersion { previous_version: String, provided_version: String },
+    InvalidContractVersion {
+        previous_version: String,
+        provided_version: String,
+    },
 
     #[error("Non nhash coin provided for transaction {types:?}")]
     InvalidFundsProvided { types: Vec<String> },

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{StdError, StdResult};
+use cosmwasm_std::StdError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -65,15 +65,14 @@ impl ContractError {
     pub fn to_result<T>(self) -> Result<T, ContractError> {
         Err(self)
     }
+    /// A simple abstraction to wrap an error response just by passing the message
+    pub fn std_err<T>(msg: impl Into<String>) -> Result<T, ContractError> {
+        Err(ContractError::Std(StdError::generic_err(msg)))
+    }
 }
 impl From<semver::Error> for ContractError {
     /// Enables SemVer issues to cast convert implicitly to contract error
     fn from(err: semver::Error) -> Self {
         Self::SemVer(err.to_string())
     }
-}
-
-/// A simple abstraction to wrap an error response just by passing the message
-pub fn std_err_result<T>(msg: impl Into<String>) -> StdResult<T> {
-    Err(StdError::generic_err(msg))
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,16 +23,16 @@ pub enum ContractError {
     #[error("No nhash amount provided during name registration")]
     NoFundsProvidedForRegistration,
 
-    #[error("Previous contract name [{previous_contract:?}] does not match provided name [{provided_contract:?}]")]
+    #[error("Current contract name [{current_contract}] does not match provided migration name [{migration_contract}]")]
     InvalidContractName {
-        previous_contract: String,
-        provided_contract: String,
+        current_contract: String,
+        migration_contract: String,
     },
 
-    #[error("Previous contract version [{previous_version}] is higher than provided version [{provided_version}]")]
+    #[error("Current contract version [{current_version}] is higher than provided migration version [{migration_version}]")]
     InvalidContractVersion {
-        previous_version: String,
-        provided_version: String,
+        current_version: String,
+        migration_version: String,
     },
 
     #[error("Non nhash coin provided for transaction {types:?}")]
@@ -52,6 +52,9 @@ pub enum ContractError {
 
     #[error("Semver parsing error: {0}")]
     SemVer(String),
+
+    #[error("Query failed: {0}")]
+    QueryError(String),
 }
 impl ContractError {
     /// Allows ContractError instances to be generically returned as a Response in a fluent manner

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub mod contract_info;
 pub mod error;
 pub mod msg;
 pub mod state;
+pub mod version_info;

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -44,7 +44,10 @@ impl MigrateMsg {
     }
 
     pub fn empty() -> MigrateMsg {
-        MigrateMsg { new_fee_amount: None, new_fee_collection_address: None }
+        MigrateMsg {
+            new_fee_amount: None,
+            new_fee_collection_address: None,
+        }
     }
 }
 

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -26,6 +26,7 @@ pub enum QueryMsg {
     QueryAddressByName { name: String },
     QueryNamesByAddress { address: String },
     SearchForNames { search: String },
+    Version {},
 }
 
 /// A type alias for contract state.

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -42,6 +42,10 @@ impl MigrateMsg {
     pub fn has_fee_changes(&self) -> bool {
         self.new_fee_amount.is_some() || self.new_fee_collection_address.is_some()
     }
+
+    pub fn empty() -> MigrateMsg {
+        MigrateMsg { new_fee_amount: None, new_fee_collection_address: None }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/src/version_info.rs
+++ b/src/version_info.rs
@@ -1,0 +1,100 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use cosmwasm_std::Storage;
+use cw_storage_plus::Item;
+use semver::Version;
+use crate::error::ContractError;
+
+// When cargo is building this project, it automatically adds these env vars for the code to infer.
+// See Cargo.toml's name and version fields in the [package] section for the values.
+// NOTE: The program verifies that migrated versions match the contract name and have a greater
+// version than that which was previous stored. Ensure to update the version field on each release
+// before migrating, because the code will reject same-version migrations.
+pub const CONTRACT_NAME: &str = env!("CARGO_CRATE_NAME");
+pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+const VERSION_INFO_NAMESPACE: &str = "version_info";
+const VERSION_INFO: Item<VersionInfoV1> = Item::new(VERSION_INFO_NAMESPACE);
+
+/// Holds both the contract's unique name and version.
+/// Used to ensure that migrations have the correct targets and are not downgrades.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct VersionInfoV1 {
+    pub contract: String,
+    pub version: String,
+}
+impl VersionInfoV1 {
+    pub fn parse_sem_ver(&self) -> Result<Version, semver::Error> {
+        self.version.parse()
+    }
+}
+
+/// Sets the contract's version definition directly to the specified VersionInfoV1 struct
+pub fn set_version_info(storage: &mut dyn Storage, version_info: &VersionInfoV1) -> Result<(), ContractError> {
+    VERSION_INFO
+        .save(storage, version_info)
+        .map_err(ContractError::Std)
+}
+
+/// Fetches, if possible, the current version information for the contract.
+pub fn get_version_info(storage: &dyn Storage) -> Result<VersionInfoV1, ContractError> {
+    VERSION_INFO.load(storage).map_err(ContractError::Std)
+}
+
+/// Sets the version info for the given contract to the derived values from the Cargo.toml file
+pub fn migrate_version_info(storage: &mut dyn Storage) -> Result<VersionInfoV1, ContractError> {
+    let version_info = VersionInfoV1 {
+        contract: CONTRACT_NAME.to_string(),
+        version: CONTRACT_VERSION.to_string(),
+    };
+    set_version_info(storage, &version_info)?;
+    Ok(version_info)
+}
+
+#[cfg(test)]
+mod tests {
+    use cosmwasm_std::testing::mock_dependencies;
+    use crate::version_info::{get_version_info, migrate_version_info, set_version_info, CONTRACT_NAME, CONTRACT_VERSION, VersionInfoV1};
+
+    #[test]
+    fn test_set_and_get_version_info() {
+        let mut deps = mock_dependencies();
+        let result = set_version_info(
+            &mut deps.storage,
+            &VersionInfoV1 {
+                contract: "CONTRACT".into(),
+                version: "4.2.0".into(),
+            }
+        );
+        assert!(result.is_ok(), "storage should succeed");
+        let info = get_version_info(&deps.storage).unwrap();
+        assert_eq!("CONTRACT", info.contract.as_str(), "the proper contract name should be returned");
+        assert_eq!("4.2.0", info.version.as_str(), "the proper contract version should be returned");
+    }
+
+    #[test]
+    fn test_migrate_version_info() {
+        let mut deps = mock_dependencies();
+        let migrate_result = migrate_version_info(&mut deps.storage).unwrap();
+        assert_eq!(
+            CONTRACT_NAME,
+            migrate_result.contract.as_str(),
+            "expected the returned version info to have the declared contract name",
+        );
+        assert_eq!(
+            CONTRACT_VERSION,
+            migrate_result.version.as_str(),
+            "expected the returned version info to have the declared contract version",
+        );
+        let stored_info = get_version_info(&deps.storage).unwrap();
+        assert_eq!(
+            migrate_result.contract.as_str(),
+            stored_info.contract.as_str(),
+            "expected the stored value for contract name to be the same as the value returned from the migrate function",
+        );
+        assert_eq!(
+            migrate_result.version.as_str(),
+            stored_info.version.as_str(),
+            "expected the stored value for version number to be the same as the value returned from the migration function",
+        );
+    }
+}

--- a/src/version_info.rs
+++ b/src/version_info.rs
@@ -1,9 +1,9 @@
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use crate::error::ContractError;
 use cosmwasm_std::Storage;
 use cw_storage_plus::Item;
+use schemars::JsonSchema;
 use semver::Version;
-use crate::error::ContractError;
+use serde::{Deserialize, Serialize};
 
 // When cargo is building this project, it automatically adds these env vars for the code to infer.
 // See Cargo.toml's name and version fields in the [package] section for the values.
@@ -29,7 +29,10 @@ impl VersionInfoV1 {
 }
 
 /// Sets the contract's version definition directly to the specified VersionInfoV1 struct
-pub fn set_version_info(storage: &mut dyn Storage, version_info: &VersionInfoV1) -> Result<(), ContractError> {
+pub fn set_version_info(
+    storage: &mut dyn Storage,
+    version_info: &VersionInfoV1,
+) -> Result<(), ContractError> {
     VERSION_INFO
         .save(storage, version_info)
         .map_err(ContractError::Std)
@@ -52,8 +55,11 @@ pub fn migrate_version_info(storage: &mut dyn Storage) -> Result<VersionInfoV1, 
 
 #[cfg(test)]
 mod tests {
+    use crate::version_info::{
+        get_version_info, migrate_version_info, set_version_info, VersionInfoV1, CONTRACT_NAME,
+        CONTRACT_VERSION,
+    };
     use cosmwasm_std::testing::mock_dependencies;
-    use crate::version_info::{get_version_info, migrate_version_info, set_version_info, CONTRACT_NAME, CONTRACT_VERSION, VersionInfoV1};
 
     #[test]
     fn test_set_and_get_version_info() {
@@ -63,12 +69,20 @@ mod tests {
             &VersionInfoV1 {
                 contract: "CONTRACT".into(),
                 version: "4.2.0".into(),
-            }
+            },
         );
         assert!(result.is_ok(), "storage should succeed");
         let info = get_version_info(&deps.storage).unwrap();
-        assert_eq!("CONTRACT", info.contract.as_str(), "the proper contract name should be returned");
-        assert_eq!("4.2.0", info.version.as_str(), "the proper contract version should be returned");
+        assert_eq!(
+            "CONTRACT",
+            info.contract.as_str(),
+            "the proper contract name should be returned"
+        );
+        assert_eq!(
+            "4.2.0",
+            info.version.as_str(),
+            "the proper contract version should be returned"
+        );
     }
 
     #[test]

--- a/src/version_info.rs
+++ b/src/version_info.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 // See Cargo.toml's name and version fields in the [package] section for the values.
 // NOTE: The program verifies that migrated versions match the contract name and have a greater
 // version than that which was previous stored. Ensure to update the version field on each release
-// before migrating, because the code will reject same-version migrations.
+// before migrating, because it's important to be able to differentiate versions as they're applied.
 pub const CONTRACT_NAME: &str = env!("CARGO_CRATE_NAME");
 pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const VERSION_INFO_NAMESPACE: &str = "version_info";


### PR DESCRIPTION
The current contract will allow anything to be migrated on top of it.  This change fleshes out versioning and fully enables our migration functionality.  It does the following:
- Sets a new version for the contract because it felt right
- Upgrades our cw2 and cw-storage-plus deps because they were incompatible with the new cosmwasm and provwasm libs we use.
- Sets the version of the contract on instantiation
- Verifies that any migrations are at least the same version of our contract (this will allow us to re-migrate to the same stored code from before but change the fee values on the fly without pushing any updates)
- Minor tweaks for readability, as stated in comments below